### PR TITLE
fix global use of must_~ method to _(xxx).must_

### DIFF
--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -4,61 +4,61 @@ require_relative 'spec_helper'
 describe Gimei do
   describe '#kanji and #to_s' do
     it '全角文字が返ること' do
-      Gimei.address.kanji.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.address.to_s.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.address.prefecture.kanji.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.address.prefecture.to_s.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.address.city.kanji.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.address.city.to_s.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.address.town.kanji.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.address.town.to_s.must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.kanji).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.to_s).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.prefecture.kanji).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.prefecture.to_s).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.city.kanji).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.city.to_s).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.town.kanji).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.town.to_s).must_match(/\A[#{Moji.zen}]+\z/)
 
-      Gimei.prefecture.kanji.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.prefecture.to_s.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.city.kanji.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.city.to_s.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.town.kanji.must_match(/\A[#{Moji.zen}]+\z/)
-      Gimei.town.to_s.must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.prefecture.kanji).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.prefecture.to_s).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.city.kanji).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.city.to_s).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.town.kanji).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.town.to_s).must_match(/\A[#{Moji.zen}]+\z/)
     end
   end
 
   describe '#hiragana' do
     it 'ひらがなが返ること' do
-      Gimei.address.hiragana.must_match(/\A[\p{hiragana}]+\z/)
-      Gimei.address.prefecture.hiragana.must_match(/\A[\p{hiragana}]+\z/)
-      Gimei.address.city.hiragana.must_match(/\A[\p{hiragana}]+\z/)
-      Gimei.address.town.hiragana.must_match(/\A[\p{hiragana}]+\z/)
+      _(Gimei.address.hiragana).must_match(/\A[\p{hiragana}]+\z/)
+      _(Gimei.address.prefecture.hiragana).must_match(/\A[\p{hiragana}]+\z/)
+      _(Gimei.address.city.hiragana).must_match(/\A[\p{hiragana}]+\z/)
+      _(Gimei.address.town.hiragana).must_match(/\A[\p{hiragana}]+\z/)
 
-      Gimei.prefecture.hiragana.must_match(/\A[\p{hiragana}]+\z/)
-      Gimei.city.hiragana.must_match(/\A[\p{hiragana}]+\z/)
-      Gimei.town.hiragana.must_match(/\A[\p{hiragana}]+\z/)
+      _(Gimei.prefecture.hiragana).must_match(/\A[\p{hiragana}]+\z/)
+      _(Gimei.city.hiragana).must_match(/\A[\p{hiragana}]+\z/)
+      _(Gimei.town.hiragana).must_match(/\A[\p{hiragana}]+\z/)
     end
   end
 
   describe '#katakana' do
     it 'カタカナが返ること' do
-      Gimei.address.katakana.must_match(/\A[\p{katakana}]+\z/)
-      Gimei.address.prefecture.katakana.must_match(/\A[\p{katakana}]+\z/)
-      Gimei.address.city.katakana.must_match(/\A[\p{katakana}]+\z/)
-      Gimei.address.town.katakana.must_match(/\A[\p{katakana}]+\z/)
+      _(Gimei.address.katakana).must_match(/\A[\p{katakana}]+\z/)
+      _(Gimei.address.prefecture.katakana).must_match(/\A[\p{katakana}]+\z/)
+      _(Gimei.address.city.katakana).must_match(/\A[\p{katakana}]+\z/)
+      _(Gimei.address.town.katakana).must_match(/\A[\p{katakana}]+\z/)
 
-      Gimei.prefecture.katakana.must_match(/\A[\p{katakana}]+\z/)
-      Gimei.city.katakana.must_match(/\A[\p{katakana}]+\z/)
-      Gimei.town.katakana.must_match(/\A[\p{katakana}]+\z/)
+      _(Gimei.prefecture.katakana).must_match(/\A[\p{katakana}]+\z/)
+      _(Gimei.city.katakana).must_match(/\A[\p{katakana}]+\z/)
+      _(Gimei.town.katakana).must_match(/\A[\p{katakana}]+\z/)
     end
   end
 
   describe '#romaji' do
     it 'ローマ字が返ること' do
-      Gimei.address.romaji.must_match(/\A[a-zA-Z\s]+\z/)
+      _(Gimei.address.romaji).must_match(/\A[a-zA-Z\s]+\z/)
 
-      Gimei.address.prefecture.romaji.must_match(/\A[a-zA-Z]+\z/)
-      Gimei.address.city.romaji.must_match(/\A[a-zA-Z]+\z/)
-      Gimei.address.town.romaji.must_match(/\A[a-zA-Z]+\z/)
+      _(Gimei.address.prefecture.romaji).must_match(/\A[a-zA-Z]+\z/)
+      _(Gimei.address.city.romaji).must_match(/\A[a-zA-Z]+\z/)
+      _(Gimei.address.town.romaji).must_match(/\A[a-zA-Z]+\z/)
 
-      Gimei.prefecture.romaji.must_match(/\A[a-zA-Z]+\z/)
-      Gimei.city.romaji.must_match(/\A[a-zA-Z]+\z/)
-      Gimei.town.romaji.must_match(/\A[a-zA-Z]+\z/)
+      _(Gimei.prefecture.romaji).must_match(/\A[a-zA-Z]+\z/)
+      _(Gimei.city.romaji).must_match(/\A[a-zA-Z]+\z/)
+      _(Gimei.town.romaji).must_match(/\A[a-zA-Z]+\z/)
     end
   end
 end

--- a/spec/gimei_spec.rb
+++ b/spec/gimei_spec.rb
@@ -6,11 +6,11 @@ describe Gimei do
     before { @name = Gimei.male }
 
     it 'Gimei::Name オブジェクトが返ること' do
-      @name.must_be_instance_of Gimei::Name
+      _(@name).must_be_instance_of Gimei::Name
     end
 
     it '#male? が true を返すこと' do
-      @name.male?.must_equal true
+      _(@name.male?).must_equal true
     end
   end
 
@@ -18,149 +18,149 @@ describe Gimei do
     before { @name = Gimei.female }
 
     it 'Gimei::Name オブジェクトが返ること' do
-      @name.must_be_instance_of Gimei::Name
+      _(@name).must_be_instance_of Gimei::Name
     end
 
     it '#female? が true を返すこと' do
-      @name.female?.must_equal true
+      _(@name.female?).must_equal true
     end
   end
 
   describe '#kanji' do
     it '全角文字とスペースが返ること' do
-      Gimei.new.kanji.must_match /\A[#{Moji.zen}\s]+\z/
+      _(Gimei.new.kanji).must_match /\A[#{Moji.zen}\s]+\z/
     end
   end
 
   describe '#to_s' do
     it '全角文字とスペースが返ること' do
-      Gimei.new.to_s.must_match /\A[#{Moji.zen}\s]+\z/
+      _(Gimei.new.to_s).must_match /\A[#{Moji.zen}\s]+\z/
     end
   end
 
   describe '.kanji' do
     it '全角文字とスペースが返ること' do
-      Gimei.kanji.must_match /\A[#{Moji.zen}\s]+\z/
+      _(Gimei.kanji).must_match /\A[#{Moji.zen}\s]+\z/
     end
   end
 
   describe '#hiragana' do
     it 'ひらがなとスペースが返ること' do
-      Gimei.new.hiragana.must_match /\A[\p{hiragana}\s]+\z/
+      _(Gimei.new.hiragana).must_match /\A[\p{hiragana}\s]+\z/
     end
   end
 
   describe '.hiragana' do
     it 'ひらがなとスペースが返ること' do
-      Gimei.hiragana.must_match /\A[\p{hiragana}\s]+\z/
+      _(Gimei.hiragana).must_match /\A[\p{hiragana}\s]+\z/
     end
   end
 
   describe '#katakana' do
     it 'カタカナとスペースが返ること' do
-      Gimei.new.katakana.must_match /\A[\p{katakana}\s]+\z/
+      _(Gimei.new.katakana).must_match /\A[\p{katakana}\s]+\z/
     end
   end
 
   describe '.katakana' do
     it 'カタカナとスペースが返ること' do
-      Gimei.katakana.must_match /\A[\p{katakana}\s]+\z/
+      _(Gimei.katakana).must_match /\A[\p{katakana}\s]+\z/
     end
   end
 
   describe '.name' do
     it 'Gimei::Name オブジェクトが返ること' do
-      Gimei.name.must_be_instance_of Gimei::Name
+      _(Gimei.name).must_be_instance_of Gimei::Name
     end
   end
 
   describe '#name' do
     it 'Gimei::Name オブジェクトが返ること' do
-      Gimei.new.name.must_be_instance_of Gimei::Name
+      _(Gimei.new.name).must_be_instance_of Gimei::Name
     end
   end
 
   describe '.first' do
     it 'Gimei::Name::First オブジェクトが返ること' do
-      Gimei.first.must_be_instance_of Gimei::Name::First
+      _(Gimei.first).must_be_instance_of Gimei::Name::First
     end
   end
 
   describe '#first' do
     it 'Gimei::Name::First オブジェクトが返ること' do
-      Gimei.new.first.must_be_instance_of Gimei::Name::First
+      _(Gimei.new.first).must_be_instance_of Gimei::Name::First
     end
   end
 
   describe '.last' do
     it 'Gimei::Name::First オブジェクトが返ること' do
-      Gimei.last.must_be_instance_of Gimei::Name::Last
+      _(Gimei.last).must_be_instance_of Gimei::Name::Last
     end
   end
 
   describe '#last' do
     it 'Gimei::Name::First オブジェクトが返ること' do
-      Gimei.new.last.must_be_instance_of Gimei::Name::Last
+      _(Gimei.new.last).must_be_instance_of Gimei::Name::Last
     end
   end
 
   describe '.romaji' do
     it 'ローマ字とスペースが返ること' do
-      Gimei.romaji.must_match(/\A[a-zA-Z\s]+\z/)
+      _(Gimei.romaji).must_match(/\A[a-zA-Z\s]+\z/)
     end
   end
 
   describe '#romaji' do
     it 'ローマ字とスペースが返ること' do
-      Gimei.new.romaji.must_match(/\A[a-zA-Z\s]+\z/)
+      _(Gimei.new.romaji).must_match(/\A[a-zA-Z\s]+\z/)
     end
   end
 
   describe '.address' do
     it 'Gimei::Address オブジェクトが返ること' do
-      Gimei.address.must_be_instance_of Gimei::Address
+      _(Gimei.address).must_be_instance_of Gimei::Address
     end
   end
 
   describe '#address' do
     it 'Gimei::Address オブジェクトが返ること' do
-      Gimei.new.address.must_be_instance_of Gimei::Address
+      _(Gimei.new.address).must_be_instance_of Gimei::Address
     end
   end
 
   describe '.prefecture' do
     it 'Gimei::Address::Prefecture オブジェクトが返ること' do
-      Gimei.prefecture.must_be_instance_of Gimei::Address::Prefecture
+      _(Gimei.prefecture).must_be_instance_of Gimei::Address::Prefecture
     end
   end
 
   describe '#prefecture' do
     it 'Gimei::Address::Prefecture オブジェクトが返ること' do
-      Gimei.new.prefecture.must_be_instance_of Gimei::Address::Prefecture
+      _(Gimei.new.prefecture).must_be_instance_of Gimei::Address::Prefecture
     end
   end
 
   describe '.city' do
     it 'Gimei::Address::City オブジェクトが返ること' do
-      Gimei.city.must_be_instance_of Gimei::Address::City
+      _(Gimei.city).must_be_instance_of Gimei::Address::City
     end
   end
 
   describe '#city' do
     it 'Gimei::Address::City オブジェクトが返ること' do
-      Gimei.new.city.must_be_instance_of Gimei::Address::City
+      _(Gimei.new.city).must_be_instance_of Gimei::Address::City
     end
   end
 
   describe '.town' do
     it 'Gimei::Address::Town オブジェクトが返ること' do
-      Gimei.town.must_be_instance_of Gimei::Address::Town
+      _(Gimei.town).must_be_instance_of Gimei::Address::Town
     end
   end
 
   describe '#town' do
     it 'Gimei::Address::Town オブジェクトが返ること' do
-      Gimei.new.town.must_be_instance_of Gimei::Address::Town
+      _(Gimei.new.town).must_be_instance_of Gimei::Address::Town
     end
   end
 end

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -6,11 +6,11 @@ describe Gimei::Name do
     before { @name = Gimei::Name.male }
 
     it 'Gimei::Name オブジェクトが返ること' do
-      @name.must_be_instance_of Gimei::Name
+      _(@name).must_be_instance_of Gimei::Name
     end
 
     it '#male? が true を返すこと' do
-      @name.male?.must_equal true
+      _(@name.male?).must_equal true
     end
   end
 
@@ -18,71 +18,71 @@ describe Gimei::Name do
     before { @name = Gimei::Name.female }
 
     it 'Gimei::Name オブジェクトが返ること' do
-      @name.must_be_instance_of Gimei::Name
+      _(@name).must_be_instance_of Gimei::Name
     end
 
     it '#female? が true を返すこと' do
-      @name.female?.must_equal true
+      _(@name.female?).must_equal true
     end
   end
 
   describe '.kanji' do
     it '全角文字とスペースが返ること' do
-      Gimei::Name.kanji.must_match(/\A[#{Moji.zen}\s]+\z/)
+      _(Gimei::Name.kanji).must_match(/\A[#{Moji.zen}\s]+\z/)
     end
   end
 
   describe '.hiragana' do
     it 'ひらがなとスペースが返ること' do
-      Gimei::Name.hiragana.must_match(/\A[\p{hiragana}\s]+\z/)
+      _(Gimei::Name.hiragana).must_match(/\A[\p{hiragana}\s]+\z/)
     end
   end
 
   describe '.katakana' do
     it 'カタカナとスペースが返ること' do
-      Gimei::Name.katakana.must_match(/\A[\p{katakana}\s]+\z/)
+      _(Gimei::Name.katakana).must_match(/\A[\p{katakana}\s]+\z/)
     end
   end
 
   describe '.romaji' do
     it 'ローマ字とスペースが返ること' do
-      Gimei::Name.romaji.must_match(/\A[a-zA-Z\s]+\z/)
+      _(Gimei::Name.romaji).must_match(/\A[a-zA-Z\s]+\z/)
     end
   end
 
   describe '#kanji' do
     it '全角文字とスペースが返ること' do
-      Gimei::Name.new.kanji.must_match(/\A[#{Moji.zen}\s]+\z/)
+      _(Gimei::Name.new.kanji).must_match(/\A[#{Moji.zen}\s]+\z/)
     end
   end
 
   describe '#hiragana' do
     it 'ひらがなとスペースが返ること' do
-      Gimei::Name.new.hiragana.must_match(/\A[\p{hiragana}\s]+\z/)
+      _(Gimei::Name.new.hiragana).must_match(/\A[\p{hiragana}\s]+\z/)
     end
   end
 
   describe '#katakana' do
     it 'カタカナとスペースが返ること' do
-      Gimei::Name.new.katakana.must_match(/\A[\p{katakana}\s]+\z/)
+      _(Gimei::Name.new.katakana).must_match(/\A[\p{katakana}\s]+\z/)
     end
   end
 
   describe '#first' do
     it 'Gimei::Name::First オブジェクトが返ること' do
-      Gimei::Name.new.first.must_be_instance_of Gimei::Name::First
+      _(Gimei::Name.new.first).must_be_instance_of Gimei::Name::First
     end
   end
 
   describe '#last' do
     it 'Gimei::Name::Last オブジェクトが返ること' do
-      Gimei::Name.new.last.must_be_instance_of Gimei::Name::Last
+      _(Gimei::Name.new.last).must_be_instance_of Gimei::Name::Last
     end
   end
 
   describe '.romaji' do
     it 'ローマ字とスペースが返ること' do
-      Gimei::Name.new.romaji.must_match(/\A[a-zA-Z\s]+\z/)
+      _(Gimei::Name.new.romaji).must_match(/\A[a-zA-Z\s]+\z/)
     end
   end
 end
@@ -92,11 +92,11 @@ describe Gimei::Name::First do
     before { @name = Gimei::Name::First.male }
 
     it 'Gimei::Name::First オブジェクトが返ること' do
-      @name.must_be_instance_of Gimei::Name::First
+      _(@name).must_be_instance_of Gimei::Name::First
     end
 
     it '#male? が true を返すこと' do
-      @name.male?.must_equal true
+      _(@name.male?).must_equal true
     end
   end
 
@@ -104,41 +104,41 @@ describe Gimei::Name::First do
     before { @name = Gimei::Name::First.female }
 
     it 'Gimei::Name::First オブジェクトが返ること' do
-      @name.must_be_instance_of Gimei::Name::First
+      _(@name).must_be_instance_of Gimei::Name::First
     end
 
     it '#female? が true を返すこと' do
-      @name.female?.must_equal true
+      _(@name.female?).must_equal true
     end
   end
 
   describe '#kanji' do
     it '全角文字が返ること' do
-      Gimei::Name::First.new.kanji.must_match(/\A#{Moji.zen}+\z/)
+      _(Gimei::Name::First.new.kanji).must_match(/\A#{Moji.zen}+\z/)
     end
   end
 
   describe '#hiragana' do
     it 'ひらがなが返ること' do
-      Gimei::Name::First.new.hiragana.must_match(/\A\p{hiragana}+\z/)
+      _(Gimei::Name::First.new.hiragana).must_match(/\A\p{hiragana}+\z/)
     end
   end
 
   describe '#katakana' do
     it 'カタカナが返ること' do
-      Gimei::Name::First.new.katakana.must_match(/\A\p{katakana}+\z/)
+      _(Gimei::Name::First.new.katakana).must_match(/\A\p{katakana}+\z/)
     end
   end
 
   describe '#to_s' do
     it '全角文字が返ること' do
-      Gimei::Name::First.new.to_s.must_match(/\A#{Moji.zen}+\z/)
+      _(Gimei::Name::First.new.to_s).must_match(/\A#{Moji.zen}+\z/)
     end
   end
 
   describe '#romaji' do
     it 'アルファベットで返ること' do
-      Gimei::Name::First.new.romaji.must_match(/\A[a-zA-Z]+\z/)
+      _(Gimei::Name::First.new.romaji).must_match(/\A[a-zA-Z]+\z/)
     end
   end
 end
@@ -148,31 +148,31 @@ describe Gimei::Name::Last do
 
   describe '#kanji' do
     it '全角文字が返ること' do
-      @name.kanji.must_match(/\A#{Moji.zen}+\z/)
+      _(@name.kanji).must_match(/\A#{Moji.zen}+\z/)
     end
   end
 
   describe '#hiragana' do
     it 'ひらがなが返ること' do
-      @name.hiragana.must_match(/\A\p{hiragana}+\z/)
+      _(@name.hiragana).must_match(/\A\p{hiragana}+\z/)
     end
   end
 
   describe '#katakana' do
     it 'カタカナが返ること' do
-      @name.katakana.must_match(/\A\p{katakana}+\z/)
+      _(@name.katakana).must_match(/\A\p{katakana}+\z/)
     end
   end
 
   describe '#to_s' do
     it '全角文字が返ること' do
-      @name.to_s.must_match(/\A#{Moji.zen}+\z/)
+      _(@name.to_s).must_match(/\A#{Moji.zen}+\z/)
     end
   end
 
   describe '#romaji' do
     it 'アルファベットで返ること' do
-      Gimei::Name::First.new.romaji.must_match(/\A[a-z|A-Z]+\z/)
+      _(Gimei::Name::First.new.romaji).must_match(/\A[a-z|A-Z]+\z/)
     end
   end
 end


### PR DESCRIPTION
minitestのメソッドの使い方が非推奨になったため、修正しました。

`DEPRECATED: global use of must_be_instance_of from /home/hamada/dev/gem/gimei/spec/gimei_spec.rb:21. Use _(obj).must_be_instance_of instead. This will fail in Minitest 6.`