### PR TITLE
Add directory 'vendor/bundle' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/bundle


### PR DESCRIPTION
When I executed `bundle install --path=vendor/bundle`, the files generated under the directory `vendor/bundle` is not ignored.

So I fixed it.
