### PR TITLE
Rename Gimei::GENDER to Gimei::GENDERS

### DIFF
--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -9,7 +9,7 @@ class Gimei
 
   NAMES = YAML.load_file(File.expand_path(File.join('..', 'data', 'names.yml'), __FILE__))
   ADDRESSES = YAML.load_file(File.expand_path(File.join('..', 'data', 'addresses.yml'), __FILE__))
-  GENDER = [:male, :female].freeze
+  GENDERS = [:male, :female].freeze
 
   def_delegators :@name, :kanji, :hiragana, :katakana, :first, :last, :male?, :female?, :romaji
   def_delegators :@address, :prefecture, :city, :town

--- a/lib/gimei/name.rb
+++ b/lib/gimei/name.rb
@@ -17,7 +17,7 @@ class Gimei::Name
   end
 
   def initialize(gender = nil)
-    @gender = gender || Gimei::GENDER.sample
+    @gender = gender || Gimei::GENDERS.sample
     @first = First.new @gender
     @last = Last.new
   end
@@ -63,7 +63,7 @@ class Gimei::Name
     def_delegators :@name, :kanji, :hiragana, :katakana, :to_s, :romaji
 
     def initialize(gender = nil)
-      @gender = gender || Gimei::GENDER.sample
+      @gender = gender || Gimei::GENDERS.sample
       @name = NameWord.new(Gimei::NAMES['first_name'][@gender.to_s].sample)
     end
 


### PR DESCRIPTION
I renamed `Gimei::GENDER` (singular) to `Gimei::GENDERS` (plural) like `Gime::NAMES` and `Gimei::ADDRESSES`.