### PR TITLE
Add Gimei::Name#gender

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ gimei.kanji          #=> "斎藤 陽菜"
 gimei.hiragana       #=> "さいとう はるな"
 gimei.katakana       #=> "サイトウ ハルナ"
 gimei.romaji         #=> "Haruna Saitou"
+gimei.gender         #=> :female
+gimei.male?          #=> false
+gimei.female?        #=> true
 gimei.last.kanji     #=> "斎藤"
 gimei.last.hiragana  #=> "さいとう"
 gimei.last.katakana  #=> "サイトウ"
@@ -36,11 +39,13 @@ gimei.first.romaji   #=> "Haruna"
 gimei = Gimei.male
 gimei.male?   #=> true
 gimei.female? #=> false
+gimei.gender  #=> :male
 gimei.kanji   #=> "小林 顕士"
 
 gimei = Gimei.female
 gimei.male?   #=> false
 gimei.female? #=> true
+gimei.gender  #=> :female
 gimei.kanji   #=> "根本 彩世"
 ```
 

--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -11,7 +11,7 @@ class Gimei
   ADDRESSES = YAML.load_file(File.expand_path(File.join('..', 'data', 'addresses.yml'), __FILE__))
   GENDERS = [:male, :female].freeze
 
-  def_delegators :@name, :kanji, :hiragana, :katakana, :first, :last, :male?, :female?, :romaji
+  def_delegators :@name, :gender, :kanji, :hiragana, :katakana, :first, :last, :male?, :female?, :romaji
   def_delegators :@address, :prefecture, :city, :town
   alias_method :to_s, :kanji
 

--- a/lib/gimei/name.rb
+++ b/lib/gimei/name.rb
@@ -1,7 +1,7 @@
 require 'romaji'
 
 class Gimei::Name
-  attr_reader :first, :last
+  attr_reader :first, :last, :gender
 
   class << self
     extend Forwardable

--- a/spec/gimei_spec.rb
+++ b/spec/gimei_spec.rb
@@ -9,6 +9,10 @@ describe Gimei do
       _(@name).must_be_instance_of Gimei::Name
     end
 
+    it '#gender が :male を返すこと' do
+      _(@name.gender).must_equal :male
+    end
+
     it '#male? が true を返すこと' do
       _(@name.male?).must_equal true
     end
@@ -21,8 +25,19 @@ describe Gimei do
       _(@name).must_be_instance_of Gimei::Name
     end
 
+    it '#gender が :female を返すこと' do
+      _(@name.gender).must_equal :female
+    end
+
     it '#female? が true を返すこと' do
       _(@name.female?).must_equal true
+    end
+  end
+
+  describe '#gender' do
+    it ':male または :female が返ること' do
+      _(Gimei.new.gender).must_be_instance_of(Symbol)
+      _(Gimei.new.gender.to_s).must_match(/\A(?:male|female)\Z/)
     end
   end
 

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -9,6 +9,10 @@ describe Gimei::Name do
       _(@name).must_be_instance_of Gimei::Name
     end
 
+    it '#gender が :male を返すこと' do
+      _(@name.gender).must_equal :male
+    end
+
     it '#male? が true を返すこと' do
       _(@name.male?).must_equal true
     end
@@ -19,6 +23,10 @@ describe Gimei::Name do
 
     it 'Gimei::Name オブジェクトが返ること' do
       _(@name).must_be_instance_of Gimei::Name
+    end
+
+    it '#gender が :female を返すこと' do
+      _(@name.gender).must_equal :female
     end
 
     it '#female? が true を返すこと' do
@@ -47,6 +55,13 @@ describe Gimei::Name do
   describe '.romaji' do
     it 'ローマ字とスペースが返ること' do
       _(Gimei::Name.romaji).must_match(/\A[a-zA-Z\s]+\z/)
+    end
+  end
+
+  describe '#gender' do
+    it ':male または :female が返ること' do
+      _(Gimei::Name.new.gender).must_be_instance_of(Symbol)
+      _(Gimei::Name.new.gender.to_s).must_match(/\A(?:male|female)\Z/)
     end
   end
 


### PR DESCRIPTION
When I have a Rails model `User` like as follows,
```ruby
class User < ApplicationRecord
  enum gender: { male: 1, female: 2 }
end
```
I want to build a user using Gimei,
```ruby
gimei = Gimei.new
user = User.new(name: gimei.kanji, gender: gimei.gender)
```

so I enable to use `Gimei::Name#gender` and `Gimei#gender`.

I think class methods `Gimei::Name.gender` and `Gimei.gender` are not necessary.