### PR TITLE
Fix warning messages

### DIFF
--- a/gimei.gemspec
+++ b/gimei.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.add_dependency('romaji')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('moji')
   gem.add_development_dependency('minitest')
   gem.add_development_dependency('coveralls')
 end

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -4,21 +4,21 @@ require_relative 'spec_helper'
 describe Gimei do
   describe '#kanji and #to_s' do
     it '全角文字が返ること' do
-      _(Gimei.address.kanji).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.address.to_s).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.address.prefecture.kanji).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.address.prefecture.to_s).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.address.city.kanji).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.address.city.to_s).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.address.town.kanji).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.address.town.to_s).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.address.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.address.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.address.prefecture.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.address.prefecture.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.address.city.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.address.city.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.address.town.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.address.town.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
 
-      _(Gimei.prefecture.kanji).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.prefecture.to_s).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.city.kanji).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.city.to_s).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.town.kanji).must_match(/\A[#{Moji.zen}]+\z/)
-      _(Gimei.town.to_s).must_match(/\A[#{Moji.zen}]+\z/)
+      _(Gimei.prefecture.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.prefecture.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.city.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.city.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.town.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
+      _(Gimei.town.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
     end
   end
 

--- a/spec/gimei_spec.rb
+++ b/spec/gimei_spec.rb
@@ -43,19 +43,19 @@ describe Gimei do
 
   describe '#kanji' do
     it '全角文字とスペースが返ること' do
-      _(Gimei.new.kanji).must_match(/\A[#{Moji.zen}\s]+\z/)
+      _(Gimei.new.kanji).must_match(/\A#{zenkaku_or_space_regexp}+\z/)
     end
   end
 
   describe '#to_s' do
     it '全角文字とスペースが返ること' do
-      _(Gimei.new.to_s).must_match(/\A[#{Moji.zen}\s]+\z/)
+      _(Gimei.new.to_s).must_match(/\A#{zenkaku_or_space_regexp}+\z/)
     end
   end
 
   describe '.kanji' do
     it '全角文字とスペースが返ること' do
-      _(Gimei.kanji).must_match(/\A[#{Moji.zen}\s]+\z/)
+      _(Gimei.kanji).must_match(/\A#{zenkaku_or_space_regexp}+\z/)
     end
   end
 

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -36,7 +36,7 @@ describe Gimei::Name do
 
   describe '.kanji' do
     it '全角文字とスペースが返ること' do
-      _(Gimei::Name.kanji).must_match(/\A[#{Moji.zen}\s]+\z/)
+      _(Gimei::Name.kanji).must_match(/\A#{zenkaku_or_space_regexp}+\z/)
     end
   end
 
@@ -67,7 +67,7 @@ describe Gimei::Name do
 
   describe '#kanji' do
     it '全角文字とスペースが返ること' do
-      _(Gimei::Name.new.kanji).must_match(/\A[#{Moji.zen}\s]+\z/)
+      _(Gimei::Name.new.kanji).must_match(/\A#{zenkaku_or_space_regexp}+\z/)
     end
   end
 
@@ -129,7 +129,7 @@ describe Gimei::Name::First do
 
   describe '#kanji' do
     it '全角文字が返ること' do
-      _(Gimei::Name::First.new.kanji).must_match(/\A#{Moji.zen}+\z/)
+      _(Gimei::Name::First.new.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
     end
   end
 
@@ -147,7 +147,7 @@ describe Gimei::Name::First do
 
   describe '#to_s' do
     it '全角文字が返ること' do
-      _(Gimei::Name::First.new.to_s).must_match(/\A#{Moji.zen}+\z/)
+      _(Gimei::Name::First.new.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
     end
   end
 
@@ -163,7 +163,7 @@ describe Gimei::Name::Last do
 
   describe '#kanji' do
     it '全角文字が返ること' do
-      _(@name.kanji).must_match(/\A#{Moji.zen}+\z/)
+      _(@name.kanji).must_match(/\A#{zenkaku_regexp}+\z/)
     end
   end
 
@@ -181,7 +181,7 @@ describe Gimei::Name::Last do
 
   describe '#to_s' do
     it '全角文字が返ること' do
-      _(@name.to_s).must_match(/\A#{Moji.zen}+\z/)
+      _(@name.to_s).must_match(/\A#{zenkaku_regexp}+\z/)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,12 @@ Coveralls.wear!
 
 require 'gimei'
 require 'minitest/autorun'
-require 'moji'
+
+def zenkaku_regexp
+  /\p{Hiragana}|\p{Katakana}|[一-龠々]/
+end
+
+def zenkaku_or_space_regexp
+  /\p{Hiragana}|\p{Katakana}|[一-龠々]|\s/
+end
+


### PR DESCRIPTION
Fix #22 

```
warning: character class has duplicated range
..<main>:139: warning: character class has duplicated range
```