### PR TITLE
データの読み込みを遅延させた

### DIFF
--- a/gimei.gemspec
+++ b/gimei.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('romaji')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('minitest')
-  gem.add_development_dependency('minitest-stub-const')
   gem.add_development_dependency('coveralls')
 end

--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -9,8 +9,6 @@ require 'gimei/config'
 class Gimei
   extend Forwardable
 
-  NAMES = YAML.load_file(File.expand_path(File.join('..', 'data', 'names.yml'), __FILE__))
-  ADDRESSES = YAML.load_file(File.expand_path(File.join('..', 'data', 'addresses.yml'), __FILE__))
   GENDERS = [:male, :female].freeze
 
   def_delegators :@name, :gender, :kanji, :hiragana, :katakana, :first, :last, :male?, :female?, :romaji
@@ -27,6 +25,14 @@ class Gimei
 
     def name(gender = nil)
       Name.new(gender)
+    end
+
+    def names
+      @names ||= YAML.load_file(File.expand_path(File.join('..', 'data', 'names.yml'), __FILE__))
+    end
+
+    def addresses
+      @addresses ||= YAML.load_file(File.expand_path(File.join('..', 'data', 'addresses.yml'), __FILE__))
     end
 
     %i[kanji hiragana katakana romaji first last].each do |method_name|

--- a/lib/gimei/address.rb
+++ b/lib/gimei/address.rb
@@ -43,7 +43,7 @@ class Gimei::Address
     end
 
     def initialize
-      @prefectures = Gimei::ADDRESSES['addresses']['prefecture'].sample(random: Gimei.config.rng)
+      @prefectures = Gimei.addresses['addresses']['prefecture'].sample(random: Gimei.config.rng)
     end
 
     alias_method :to_s, :kanji
@@ -67,7 +67,7 @@ class Gimei::Address
     end
 
     def initialize
-      @cities = Gimei::ADDRESSES['addresses']['city'].sample(random: Gimei.config.rng)
+      @cities = Gimei.addresses['addresses']['city'].sample(random: Gimei.config.rng)
     end
 
     alias_method :to_s, :kanji
@@ -91,7 +91,7 @@ class Gimei::Address
     end
 
     def initialize
-      @towns = Gimei::ADDRESSES['addresses']['town'].sample(random: Gimei.config.rng)
+      @towns = Gimei.addresses['addresses']['town'].sample(random: Gimei.config.rng)
     end
 
     alias_method :to_s, :kanji

--- a/lib/gimei/name.rb
+++ b/lib/gimei/name.rb
@@ -69,7 +69,7 @@ class Gimei::Name
 
     def initialize(gender = nil)
       @gender = gender || Gimei::GENDERS.sample(random: Gimei.config.rng)
-      @name = NameWord.new(Gimei::NAMES['first_name'][@gender.to_s].sample(random: Gimei.config.rng))
+      @name = NameWord.new(Gimei.names['first_name'][@gender.to_s].sample(random: Gimei.config.rng))
     end
 
     def male?
@@ -86,7 +86,7 @@ class Gimei::Name
     def_delegators :@name, :kanji, :hiragana, :katakana, :to_s, :romaji
 
     def initialize
-      @name = NameWord.new(Gimei::NAMES['last_name'].sample(random: Gimei.config.rng))
+      @name = NameWord.new(Gimei.names['last_name'].sample(random: Gimei.config.rng))
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ Coveralls.wear!
 
 require 'gimei'
 require 'minitest/autorun'
-require 'minitest/stub_const'
 
 def zenkaku_regexp
   /\p{Hiragana}|\p{Katakana}|[一-龠々]/

--- a/spec/unique_spec.rb
+++ b/spec/unique_spec.rb
@@ -9,7 +9,7 @@ describe 'Gimei.unique' do
   describe '#clear' do
     describe '名前が枯渇してからclearを実行し、再度名前を取得しようとしたとき' do
       it 'Gimei::RetryLimitExceededed例外が発生しないこと' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -22,7 +22,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇してからclear(:name)を実行し再度名前を取得しようとしたとき' do
       it 'Gimei::RetryLimitExceededed例外が発生しないこと' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => {'male' => [%w[真一 しんいち シンイチ]]},
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -35,7 +35,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇してからclear(:address)を実行し再度名前を取得しようとしたとき' do
       it 'Gimei::RetryLimitExceededed例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => {'male' => [%w[真一 しんいち シンイチ]]},
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -52,7 +52,7 @@ describe 'Gimei.unique' do
   describe '#male' do
     describe '名前が枯渇していないとき' do
       it '一意な名前(フルネームの漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
         }) do
@@ -63,7 +63,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇したとき' do
       it 'Gimei::RetryLimitExceededed例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -79,7 +79,7 @@ describe 'Gimei.unique' do
   describe '#female' do
     describe '名前が枯渇していないとき' do
       it '一意な名前(フルネームの漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'female' => [%w[花子 はなこ ハナコ]] },
           'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
         }) do
@@ -90,7 +90,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇したとき' do
       it 'Gimei::RetryLimitExceededed例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'female' => [%w[花子 はなこ ハナコ]] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -106,7 +106,7 @@ describe 'Gimei.unique' do
   describe '#first' do
     describe '名が枯渇していないとき' do
       it '一意な名(漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ], %w[真二 しんじ シンジ]] },
           'last_name' => %w[]
         }) do
@@ -117,7 +117,7 @@ describe 'Gimei.unique' do
 
     describe '名が枯渇したとき' do
       it 'Gimei::RetryLimitExceeded例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => []
         }) do
@@ -133,7 +133,7 @@ describe 'Gimei.unique' do
   describe '#last' do
     describe '姓が枯渇していないとき' do
       it '一意な姓(漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [], 'female' => [] },
           'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
         }) do
@@ -144,7 +144,7 @@ describe 'Gimei.unique' do
 
     describe '姓が枯渇したとき' do
       it 'Gimei::RetryLimitExceeded例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [], 'female' => [] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -160,7 +160,7 @@ describe 'Gimei.unique' do
   describe '#kanji' do
     describe '名前が枯渇していないとき' do
       it '一意な名前(フルネームの漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
         }) do
@@ -171,7 +171,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇したとき' do
       it 'Gimei::RetryLimitExceededed例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -187,7 +187,7 @@ describe 'Gimei.unique' do
   describe '#hiragana' do
     describe '名前が枯渇していないとき' do
       it '一意な名前(フルネームの漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
         }) do
@@ -198,7 +198,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇したとき' do
       it 'Gimei::RetryLimitExceededed例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -214,7 +214,7 @@ describe 'Gimei.unique' do
   describe '#katakana' do
     describe '名前が枯渇していないとき' do
       it '一意な名前(フルネームの漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
         }) do
@@ -225,7 +225,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇したとき' do
       it 'Gimei::RetryLimitExceededed例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -241,7 +241,7 @@ describe 'Gimei.unique' do
   describe '#romaji' do
     describe '名前が枯渇していないとき' do
       it '一意な名前(フルネームの漢字単位)が返ること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
         }) do
@@ -252,7 +252,7 @@ describe 'Gimei.unique' do
 
     describe '名前が枯渇したとき' do
       it 'Gimei::RetryLimitExceededed例外が発生すること' do
-        Gimei.stub_const(:NAMES, {
+        Gimei.stub(:names, {
           'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
           'last_name' => [%w[前島 まえしま マエシマ]]
         }) do
@@ -268,7 +268,7 @@ describe 'Gimei.unique' do
   describe '#address' do
     describe '住所が枯渇していないとき' do
       it '一意な住所(漢字単位)が返ること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [%w[東京都 とうきょうと トウキョウト]],
             'city' => [%w[渋谷区 しぶやく シブヤク]],
@@ -282,7 +282,7 @@ describe 'Gimei.unique' do
 
     describe '住所が枯渇したとき' do
       it 'Gimei::RetryLimitExceeded例外が発生すること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [%w[東京都 とうきょうと トウキョウト]],
             'city' => [%w[渋谷区 しぶやく シブヤク]],
@@ -301,7 +301,7 @@ describe 'Gimei.unique' do
   describe '#prefecture' do
     describe '県が枯渇していないとき' do
       it '一意な県が返ること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [%w[東京都 とうきょうと トウキョウト], %w[静岡県 しずおかけん シズオカケン]],
             'city' => [],
@@ -315,7 +315,7 @@ describe 'Gimei.unique' do
 
     describe '県が枯渇したとき' do
       it 'Gimei::RetryLimitExceeded例外が発生すること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [%w[東京都 とうきょうと トウキョウト]],
             'city' => [],
@@ -334,7 +334,7 @@ describe 'Gimei.unique' do
   describe '#city' do
     describe '市区町村が枯渇していないとき' do
       it '一意な市区町村が返ること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [],
             'city' => [%w[渋谷区 しぶやく シブヤク], %w[新宿区 しんじゅくく シンジュクク]],
@@ -348,7 +348,7 @@ describe 'Gimei.unique' do
 
     describe '市区町村が枯渇したとき' do
       it 'Gimei::RetryLimitExceeded例外が発生すること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [],
             'city' => [%w[渋谷区 しぶやく シブヤク]],
@@ -367,7 +367,7 @@ describe 'Gimei.unique' do
   describe '#town' do
     describe 'その他住所が枯渇していないとき' do
       it '一意なその他住所が返ること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [],
             'city' => [],
@@ -381,7 +381,7 @@ describe 'Gimei.unique' do
 
     describe 'その他住所が枯渇したとき' do
       it 'Gimei::RetryLimitExceeded例外が発生すること' do
-        Gimei.stub_const(:ADDRESSES, {
+        Gimei.stub(:addresses, {
           'addresses' => {
             'prefecture' => [],
             'city' => [],


### PR DESCRIPTION
Fix #39

`bundle exec derailed bundle:mem` の結果

## before

```
TOP: 18.4063 MiB
  gimei: 18.3828 MiB
    yaml: 0.5508 MiB
      psych: 0.543 MiB
        psych/visitors: 0.3164 MiB
    gimei/name: 0.4531 MiB
      romaji: 0.418 MiB
```

## after

```
TOP: 1.7852 MiB
  gimei: 1.7656 MiB
    yaml: 1.0742 MiB
      psych: 1.0625 MiB
        psych/visitors: 0.5352 MiB
    gimei/name: 0.4727 MiB
      romaji: 0.3867 MiB
```
