### PR TITLE
Gimei::Name#family, #given を追加 - Add Gimei::Name#family, #given

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ gimei.first.katakana #=> "ハルナ"
 gimei.first.romaji   #=> "Haruna"
 ```
 
+`gimei.last`, `gimei.first` の代わりに、`gimei.family`, `gimei.given` を用いることもできます。
+
+```ruby
+gimei.family.kanji     #=> "斎藤"
+gimei.family.hiragana  #=> "さいとう"
+gimei.family.katakana  #=> "サイトウ"
+gimei.family.romaji    #=> "Saitou"
+
+gimei.given.kanji    #=> "陽菜"
+gimei.given.hiragana #=> "はるな"
+gimei.given.katakana #=> "ハルナ"
+gimei.given.romaji   #=> "Haruna"
+```
+
 下記のように男性／女性の名前を返すことを明示的に指定できます。`Gimei.name` の場合は男女の名前を等確率で返します。
 
 ```ruby
@@ -64,6 +78,16 @@ Gimei.first.kanji    #=> "結菜"
 Gimei.first.hiragana #=> "ここあ"
 Gimei.first.katakana #=> "ヤマト"
 Gimei.first.romaji   #=> "Noriyuki"
+
+Gimei.family.kanji     #=> "黒沢"
+Gimei.family.hiragana  #=> "いずみ"
+Gimei.family.katakana  #=> "エノモト"
+Gimei.family.romaji    #=> "Okada"
+
+Gimei.given.kanji    #=> "航"
+Gimei.given.hiragana #=> "まさみつ"
+Gimei.given.katakana #=> "ユカ"
+Gimei.given.romaji   #=> "Haruto"
 ```
 
 同じ名前を二度取得したくない場合には、以下のように`unique`を挟みます。次のようにすると、利用した名前をGimei内で保持することで必ず一意な名前を返すようにできます。
@@ -109,6 +133,9 @@ Gimei.unique.clear(:first) # Gimei.unique.first の結果を消去
 - `Gimei.unique.male`
 - `Gimei.unique.female`
 - `Gimei.unique.kanji`
+
+`Gimei.unique.family` で生成された名前は `Gimei.unique.clear(:last)` で消去します。
+また、`Gimei.unique.given` で生成された名前は `Gimei.unique.clear(:first)` で消去します。
 
 出力される名前の候補となるデータは `lib/data/names.yml` にあるので、必要であればファイルを修正してください。
 

--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -39,7 +39,7 @@ class Gimei
       @addresses ||= YAML.load_file(File.expand_path(File.join('..', 'data', 'addresses.yml'), __FILE__))
     end
 
-    %i[kanji hiragana katakana romaji first last].each do |method_name|
+    %i[kanji hiragana katakana romaji first last family given].each do |method_name|
       define_method(method_name) do |gender = nil|
         name(gender).public_send(method_name)
       end

--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -58,6 +58,9 @@ class Gimei
         @unique.define_unique_method(method_name)
       end
 
+      @unique.define_unique_method(:family, :last)
+      @unique.define_unique_method(:given, :first)
+
       %i[male female kanji].each do |method_name|
         @unique.define_unique_method(method_name, :name)
       end

--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -11,7 +11,11 @@ class Gimei
 
   GENDERS = [:male, :female].freeze
 
-  def_delegators :@name, :gender, :kanji, :hiragana, :katakana, :first, :last, :male?, :female?, :romaji
+  def_delegators :@name,
+                 :first, :last, :gender,
+                 :kanji, :hiragana, :katakana, :romaji,
+                 :male?, :female?,
+                 :family, :given
   def_delegators :@address, :prefecture, :city, :town
   alias_method :to_s, :kanji
 

--- a/lib/gimei/name.rb
+++ b/lib/gimei/name.rb
@@ -14,7 +14,7 @@ class Gimei::Name
       new(:female)
     end
 
-    %i[kanji hiragana katakana romaji first last].each do |method_name|
+    %i[kanji hiragana katakana romaji first last family given].each do |method_name|
       define_method(method_name) do |gender = nil|
         new(gender).public_send(method_name)
       end
@@ -52,6 +52,9 @@ class Gimei::Name
   end
 
   alias_method :to_s, :kanji
+
+  alias_method :family, :last
+  alias_method :given, :first
 
   class First
     class << self

--- a/spec/gimei_spec.rb
+++ b/spec/gimei_spec.rb
@@ -119,9 +119,21 @@ describe Gimei do
     end
   end
 
+  describe '.family' do
+    it 'Gimei::Name::Last オブジェクトが返ること' do
+      _(Gimei.family).must_be_instance_of Gimei::Name::Last
+    end
+  end
+
   describe '#family' do
     it 'Gimei::Name::Last オブジェクトが返ること' do
       _(Gimei.new.family).must_be_instance_of Gimei::Name::Last
+    end
+  end
+
+  describe '.given' do
+    it 'Gimei::Name::First オブジェクトが返ること' do
+      _(Gimei.given).must_be_instance_of Gimei::Name::First
     end
   end
 

--- a/spec/gimei_spec.rb
+++ b/spec/gimei_spec.rb
@@ -119,6 +119,18 @@ describe Gimei do
     end
   end
 
+  describe '#family' do
+    it 'Gimei::Name::Last オブジェクトが返ること' do
+      _(Gimei.new.family).must_be_instance_of Gimei::Name::Last
+    end
+  end
+
+  describe '#given' do
+    it 'Gimei::Name::First オブジェクトが返ること' do
+      _(Gimei.new.given).must_be_instance_of Gimei::Name::First
+    end
+  end
+
   describe '.romaji' do
     it 'ローマ字とスペースが返ること' do
       _(Gimei.romaji).must_match(/\A[a-zA-Z\s]+\z/)

--- a/spec/name_spec.rb
+++ b/spec/name_spec.rb
@@ -70,6 +70,18 @@ describe Gimei::Name do
     end
   end
 
+  describe '.family' do
+    it 'Gimei::Name::Last オブジェクトが返ること' do
+      _(Gimei::Name.family).must_be_instance_of Gimei::Name::Last
+    end
+  end
+
+  describe '.given' do
+    it 'Gimei::Name::First オブジェクトが返ること' do
+      _(Gimei::Name.given).must_be_instance_of Gimei::Name::First
+    end
+  end
+
   describe '#gender' do
     it ':male または :female が返ること' do
       _(Gimei::Name.new.gender).must_be_instance_of(Symbol)
@@ -110,6 +122,18 @@ describe Gimei::Name do
   describe '#last' do
     it 'Gimei::Name::Last オブジェクトが返ること' do
       _(Gimei::Name.new.last).must_be_instance_of Gimei::Name::Last
+    end
+  end
+
+  describe '#family' do
+    it 'Gimei::Name::Last オブジェクトが返ること' do
+      _(Gimei::Name.new.family).must_be_instance_of Gimei::Name::Last
+    end
+  end
+
+  describe '#given' do
+    it 'Gimei::Name::First オブジェクトが返ること' do
+      _(Gimei::Name.new.given).must_be_instance_of Gimei::Name::First
     end
   end
 end

--- a/spec/unique_spec.rb
+++ b/spec/unique_spec.rb
@@ -157,6 +157,60 @@ describe 'Gimei.unique' do
     end
   end
 
+  describe '#family' do
+    describe '姓が枯渇していないとき' do
+      it '一意な姓(漢字単位)が返ること' do
+        Gimei.stub(:names, {
+          'first_name' => { 'male' => [], 'female' => [] },
+          'last_name' => [%w[前島 まえしま マエシマ], %w[神谷 かみや カミヤ]]
+        }) do
+          _([Gimei.unique.family.kanji, Gimei.unique.family.kanji].sort).must_equal %w[前島 神谷]
+        end
+      end
+    end
+
+    describe '姓が枯渇したとき' do
+      it 'Gimei::RetryLimitExceeded例外が発生すること' do
+        Gimei.stub(:names, {
+          'first_name' => { 'male' => [], 'female' => [] },
+          'last_name' => [%w[前島 まえしま マエシマ]]
+        }) do
+          assert_raises Gimei::RetryLimitExceeded do
+            Gimei.unique.family
+            Gimei.unique.family
+          end
+        end
+      end
+    end
+  end
+
+  describe '#given' do
+    describe '名が枯渇していないとき' do
+      it '一意な名(漢字単位)が返ること' do
+        Gimei.stub(:names, {
+          'first_name' => { 'male' => [%w[真一 しんいち シンイチ], %w[真二 しんじ シンジ]] },
+          'last_name' => %w[]
+        }) do
+          _([Gimei.unique.given(:male).kanji, Gimei.unique.given(:male).kanji].sort).must_equal %w[真一 真二]
+        end
+      end
+    end
+
+    describe '名が枯渇したとき' do
+      it 'Gimei::RetryLimitExceeded例外が発生すること' do
+        Gimei.stub(:names, {
+          'first_name' => { 'male' => [%w[真一 しんいち シンイチ]] },
+          'last_name' => []
+        }) do
+          assert_raises Gimei::RetryLimitExceeded do
+            Gimei.unique.given(:male)
+            Gimei.unique.given(:male)
+          end
+        end
+      end
+    end
+  end
+
   describe '#kanji' do
     describe '名前が枯渇していないとき' do
       it '一意な名前(フルネームの漢字単位)が返ること' do


### PR DESCRIPTION
Gimei::Name#first, #last の alias として，#family, #given を定義しました．

----

Gimei::Name#first, Gimei::Name#last はそれぞれ名，姓を取得するメソッドですが，日本での氏名は「姓→名」の順です．

時折「#first で取得できるのは姓なのか，名なのか」と迷ってしまうことがありますし，#first, #last というメソッド名は日本人の感覚になじまないと思います．

また，#first, #last というメソッド名は配列の最初・最後の要素を取得するときに使うものという印象が強く，別のメソッド名を使いたくなるケースもあるのでは，という気がしています．

極端な例ですが，first という名前の使用箇所を grep したときに Array#first の使用箇所だけ出てきてほしいのに，Gimei::Name#first の使用箇所も出てきてしまう，というケースがあると思います．

Gimei::Name#family, #given があればこうした問題は解消できますので，ぜひ採用お願いします．
