### PR TITLE
デフォルトで srand で再現可能にする

### DIFF
--- a/lib/gimei/config.rb
+++ b/lib/gimei/config.rb
@@ -2,7 +2,7 @@ class Gimei
   class Config
     attr_accessor :rng
 
-    def initialize(rng: Random.new)
+    def initialize(rng: Random)
       @rng = rng
     end
   end


### PR DESCRIPTION
rspec を `Kernel.srand config.seed` の設定で使っているんですが、 `Gimei` の結果に再現性がない事に気づきました。
設定で変更できるようですが、デフォルトは `srand` で設定されるデフォルトの RNG を使うのがいいと思います。
`Random` クラスオブジェクトを使うのは Faker の https://github.com/faker-ruby/faker/pull/2488 と同じです。

before:
```
irb(main):001:0> srand 42
=> 210865224690408955513486590071985786719
irb(main):002:0> Gimei.kanji
=> "長尾 憲剛"
irb(main):003:0> Gimei.kanji
=> "岡村 芽依"
irb(main):004:0> Gimei.kanji
=> "永井 恵子"
irb(main):005:0> srand 42
=> 42
irb(main):006:0> Gimei.kanji
=> "今野 由貴子"
irb(main):007:0> Gimei.kanji
=> "三上 菜夕"
irb(main):008:0> Gimei.kanji
=> "柳田 基之"
irb(main):009:0> 
```

after:
```
irb(main):001:0> srand 42
=> 16380877625997386394282233687557709970
irb(main):002:0> Gimei.kanji
=> "飯島 誠吾"
irb(main):003:0> Gimei.kanji
=> "篠原 卓朗"
irb(main):004:0> Gimei.kanji
=> "川口 響生"
irb(main):005:0> srand 42
=> 42
irb(main):006:0> Gimei.kanji
=> "飯島 誠吾"
irb(main):007:0> Gimei.kanji
=> "篠原 卓朗"
irb(main):008:0> Gimei.kanji
=> "川口 響生"
```
