### PR TITLE
def_delegatorsの第一引数にクラスを渡すときは文字列を使う

### DIFF
--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -24,7 +24,7 @@ class Gimei
   class << self
     extend Forwardable
 
-    def_delegators Gimei::Name, :male, :female
+    def_delegators 'Gimei::Name', :male, :female
     def_delegators :address, :prefecture, :city, :town
 
     def name(gender = nil)


### PR DESCRIPTION
下記の型情報を見る限り、def_delegators(とそのaliasのdef_instance_delegators)メソッドの第一引数は文字列もしくはシンボルを期待しているのでそれに合わせた。

[rbs/stdlib/forwardable/0/forwardable.rbs at master · ruby/rbs](https://github.com/ruby/rbs/blob/4b6f5db7faa51d6c914c166795acd7af8038afd6/stdlib/forwardable/0/forwardable.rbs#L174)

internedの定義は↓

[rbs/core/builtin.rbs at master · ruby/rbs](https://github.com/ruby/rbs/blob/4b6f5db7faa51d6c914c166795acd7af8038afd6/core/builtin.rbs#L270)
