### PR TITLE
Ruby 3.3のサポート

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'head']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'head']
         include:
           - ruby-version: 'head'
             allow_failures: 'true'

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ Gimei.address.kanji #=> "熊本県日進市東場内"
 
 ## Supported versions
 
-- 2.2.x
 - 2.3.x
 - 2.4.x
 - 2.5.x
@@ -247,6 +246,7 @@ Gimei.address.kanji #=> "熊本県日進市東場内"
 - 3.0.x
 - 3.1.x
 - 3.2.x
+- 3.3.x
 
 ## 他言語による実装
 


### PR DESCRIPTION
CIにRuby3.3を追加。

READMEにRuby2.2がサポートされている記述があったが下記のコミットで2.2のサポートは落としていたので一緒に更新した。

[bundler 2系はRuby2.3+対応なので、gimeiも合わせて2.3+対応に変更する · willnet/gimei@0910691](https://github.com/willnet/gimei/commit/09106913383e6a881e796c64520b713c4cebbdd9)
