### PR TITLE
Gimei.kanjiなどの委譲先が間違っているのをなおした

### DIFF
--- a/lib/gimei.rb
+++ b/lib/gimei.rb
@@ -42,9 +42,9 @@ class Gimei
     %i[kanji hiragana katakana romaji first last family given].each do |method_name|
       class_eval(<<~METHOD, __FILE__, __LINE__ + 1)
         def #{method_name}(gender = nil)
-          new(gender).#{method_name}
+          name(gender).#{method_name}
         end
-       METHOD
+      METHOD
     end
 
     def address


### PR DESCRIPTION
https://github.com/willnet/gimei/commit/439f53429a559e2ec8f942dc3dea3e10b82493cd#diff-628bde67a94b8827a18584690a7516c89defdcfd703db326c567b6d26f834600L43-R47 の修正が間違えていた
